### PR TITLE
Add OpenBSD support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,8 @@ readme = "README.md"
 keywords = ["wifi","hotspots","network"]
 license = "Apache-2.0"
 
-[dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 regex = "0.1"
+
+[target.'cfg(target_os = "openbsd")'.dependencies]
+nix = "0.9.*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,23 +36,60 @@
 //! Alternatively if you've cloned the the Git repo, you can run the above example
 //! using: `cargo run --example scan`.
 
-extern crate regex;
-#[doc(no_inline)]
-use regex::Regex;
+#[cfg(target_os = "openbsd")]
+#[macro_use]
+extern crate nix;
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+extern crate regex;
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "openbsd")]
+mod openbsd;
+
+#[cfg(target_os = "linux")]
+pub use linux::scan;
+#[cfg(target_os = "macos")]
+pub use macos::scan;
+#[cfg(target_os = "openbsd")]
+pub use openbsd::scan;
+
+use std::convert;
+use std::string::FromUtf8Error;
 
 #[allow(missing_docs)]
-#[derive(Debug,PartialEq,Eq)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
     SyntaxRegexError,
     CommandNotFound,
     NoMatch,
     FailedToParse,
     NoValue,
+    FromUtf8Error,
+    DiscoveryError(&'static str),
+
+    #[cfg(target_os = "openbsd")]
+    NixError(nix::Error),
+}
+
+#[cfg(target_os = "openbsd")]
+impl convert::From<nix::Error> for Error {
+    fn from(e: nix::Error) -> Self {
+        Error::NixError(e)
+    }
+}
+
+impl convert::From<FromUtf8Error> for Error {
+    fn from(_e: FromUtf8Error) -> Self {
+        Error::FromUtf8Error
+    }
 }
 
 /// Wifi struct used to return information about wifi hotspots
-#[derive(Debug,PartialEq,Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Wifi {
     /// mac address
     pub mac: String,
@@ -62,292 +99,4 @@ pub struct Wifi {
     pub signal_level: String,
     /// this field is currently empty in the Linux version of the lib
     pub security: String,
-}
-
-/// Returns a list of WiFi hotspots in your area - (OSX/MacOS) uses `airport`
-#[cfg(target_os="macos")]
-pub fn scan() -> Result<Vec<Wifi>, Error> {
-    use std::process::Command;
-    let output = try!(Command::new("/System/Library/PrivateFrameworks/Apple80211.\
-    framework/Versions/Current/Resources/airport")
-                          .arg("-s")
-                          .output()
-                          .map_err(|_| Error::CommandNotFound));
-
-    let data = String::from_utf8_lossy(&output.stdout);
-
-    parse_airport(&data)
-}
-
-/// Returns a list of WiFi hotspots in your area - (Linux) uses `iwlist`
-#[cfg(target_os="linux")]
-pub fn scan() -> Result<Vec<Wifi>, Error> {
-    use std::env;
-    use std::process::Command;
-
-    const PATH_ENV: &'static str = "PATH";
-    let path_system = "/usr/sbin:/sbin";
-    let path = env::var_os(PATH_ENV).map_or(path_system.to_string(), |v| {
-        format!("{}:{}", v.to_string_lossy().into_owned(), path_system)
-    });
-
-    let output = try!(Command::new("iwlist")
-                          .env(PATH_ENV, path)
-                          .arg("scan")
-                          .output()
-                          .map_err(|_| Error::CommandNotFound));
-
-    let data = String::from_utf8_lossy(&output.stdout);
-
-    parse_iwlist(&data)
-}
-
-
-#[allow(dead_code)]
-fn parse_airport(network_list: &str) -> Result<Vec<Wifi>, Error> {
-    let mut wifis: Vec<Wifi> = Vec::new();
-    let mut lines = network_list.lines();
-    let headers = lines.next().unwrap();
-
-    let headers_string = String::from(headers);
-    // FIXME: Turn these into non panicking Errors (ok_or breaks it)
-    let col_mac = headers_string.find("BSSID").expect("failed to find BSSID");
-    let col_rrsi = headers_string.find("RSSI").expect("failed to find RSSI");
-    let col_channel = headers_string.find("CHANNEL").expect("failed to find CHANNEL");
-    let col_ht = headers_string.find("HT").expect("failed to find HT");
-    let col_security = headers_string.find("SECURITY").expect("failed to find SECURITY");
-
-    for line in lines {
-        let ssid = &line[..col_mac].trim();
-        let mac = &line[col_mac..col_rrsi].trim();
-        let signal_level = &line[col_rrsi..col_channel].trim();
-        let channel = &line[col_channel..col_ht].trim();
-        let security = &line[col_security..].trim();
-
-        wifis.push(Wifi {
-            mac: mac.to_string(),
-            ssid: ssid.to_string(),
-            channel: channel.to_string(),
-            signal_level: signal_level.to_string(),
-            security: security.to_string(),
-        });
-    }
-
-    Ok(wifis)
-}
-
-#[allow(dead_code)]
-fn parse_iwlist(network_list: &str) -> Result<Vec<Wifi>, Error> {
-    let mut wifis: Vec<Wifi> = Vec::new();
-
-    let cell_regex = try!(Regex::new(r"Cell [0-9]{2,} - Address:")
-                              .map_err(|_| Error::SyntaxRegexError));
-
-    let mac_regex =
-        try!(Regex::new(r"([0-9a-zA-Z]{1}[0-9a-zA-Z]{1}[:]{1}){5}[0-9a-zA-Z]{1}[0-9a-zA-Z]{1}")
-                 .map_err(|_| Error::SyntaxRegexError));
-
-    for block in cell_regex.split(&network_list) {
-        let mut lines = block.lines();
-
-        let mut wifi_mac = String::new();
-        let mut wifi_ssid = String::new();
-        let mut wifi_channel = String::new();
-        let mut wifi_rssi = String::new();
-        let wifi_security = String::new(); // FIXME needs implementing
-
-        let mac_matches = mac_regex.captures(try!(lines.next().ok_or(Error::NoValue)));
-
-        if let Some(matches) = mac_matches {
-            if let Some(mac) = matches.at(0) {
-                wifi_mac = mac.to_string();
-            }
-        }
-
-        for line in lines {
-            if line.find("ESSID:").is_some() {
-                let ssid = line.split(":").nth(1).unwrap_or("").replace("\"", "");
-                wifi_ssid = ssid.to_string();
-            } else if line.find("Frequency:").is_some() {
-                wifi_channel = line.split("Channel")
-                                   .nth(1)
-                                   .unwrap_or("")
-                                   .replace(")", "")
-                                   .trim()
-                                   .to_string();
-                // println!("Channel: {}", wifi_channel);
-            } else if line.find("Signal level").is_some() {
-                if line.find("Quality").is_some() {
-                    // case1
-                    wifi_rssi = line.split("Signal level=")
-                                    .nth(1)
-                                    .unwrap_or("")
-                                    .replace("dBm", "")
-                                    .trim()
-                                    .to_string();
-                    // println!("Signal level (case1): {}", wifi_rssi);
-                } else {
-                    let re = try!(Regex::new(r"Signal level=(\d+)/100")
-                                      .map_err(|_| Error::SyntaxRegexError));
-                    let value_raw = try!(try!(re.captures(line).ok_or(Error::FailedToParse))
-                                             .at(1)
-                                             .ok_or(Error::NoValue));
-                    let value = try!(value_raw.parse::<i32>().map_err(|_| Error::FailedToParse));
-                    let strength_calc = ((100 * value) / 100) / 2 - 100;
-                    wifi_rssi = strength_calc.to_string();
-
-                    // println!("Signal level (case3): {}", wifi_rssi);
-                }
-            }
-
-
-            // FIXME make less vomit inducing
-            if !wifi_ssid.is_empty() && !wifi_mac.is_empty() && !wifi_rssi.is_empty() {
-                wifis.push(Wifi {
-                    ssid: wifi_ssid.to_string(),
-                    mac: wifi_mac.to_string(),
-                    channel: wifi_channel.to_string(),
-                    signal_level: wifi_rssi.to_string(),
-                    security: wifi_security.to_string(),
-                });
-
-                wifi_ssid = String::new();
-                wifi_mac = String::new();
-                wifi_rssi = String::new();
-                wifi_channel = String::new();
-            }
-        } // for
-    }
-    Ok(wifis)
-}
-
-#[test]
-fn should_parse_iwlist_type_1() {
-    let mut expected: Vec<Wifi> = Vec::new();
-    expected.push(Wifi {
-        mac: "00:35:1A:6F:0F:40".to_string(),
-        ssid: "TEST-Wifi".to_string(),
-        channel: "6".to_string(),
-        signal_level: "-72".to_string(),
-        security: "".to_string(),
-    });
-
-    expected.push(Wifi {
-        mac: "00:F2:8B:8F:58:77".to_string(),
-        ssid: "<hidden>".to_string(),
-        channel: "11".to_string(),
-        signal_level: "-71".to_string(),
-        security: "".to_string(),
-    });
-
-    // FIXME: should be a better way to create test fixtures
-    use std::path::PathBuf;
-    let mut path = PathBuf::new();
-    path.push("tests");
-    path.push("fixtures");
-    path.push("iwlist");
-    path.push("iwlist01_ubuntu1404.txt");
-
-    let file_path = path.as_os_str();
-
-    use std::fs::File;
-    use std::io::Read;
-
-    let mut file = File::open(&file_path).unwrap();
-
-    let mut filestr = String::new();
-    let result = file.read_to_string(&mut filestr).unwrap();
-    // println!("Read {} bytes", result);
-
-    let result = parse_iwlist(&filestr).unwrap();
-    assert_eq!(expected[0], result[0]);
-    assert_eq!(expected[1], result[28]);
-}
-
-#[test]
-fn should_parse_iwlist_type_2() {
-    let mut expected: Vec<Wifi> = Vec::new();
-
-    expected.push(Wifi {
-        mac: "D4:D1:84:50:76:45".to_string(),
-        ssid: "gsy-97796".to_string(),
-        channel: "6".to_string(),
-        signal_level: "-76".to_string(),
-        security: "".to_string(),
-    });
-
-    expected.push(Wifi {
-        mac: "7C:B7:33:AE:3B:05".to_string(),
-        ssid: "visitor-18170".to_string(),
-        channel: "9".to_string(),
-        signal_level: "-70".to_string(),
-        security: "".to_string(),
-    });
-
-    // FIXME: should be a better way to create test fixtures
-    use std::path::PathBuf;
-    let mut path = PathBuf::new();
-    path.push("tests");
-    path.push("fixtures");
-    path.push("iwlist");
-    path.push("iwlist02_raspi.txt");
-
-    let file_path = path.as_os_str();
-
-    use std::fs::File;
-    use std::io::Read;
-
-    let mut file = File::open(&file_path).unwrap();
-
-    let mut filestr = String::new();
-    let result = file.read_to_string(&mut filestr).unwrap();
-    // println!("Read {} bytes", result);
-
-    let result = parse_iwlist(&filestr).unwrap();
-    assert_eq!(expected[0], result[0]);
-    assert_eq!(expected[1], result[2]);
-}
-
-#[test]
-fn should_parse_airport() {
-    let mut expected: Vec<Wifi> = Vec::new();
-    expected.push(Wifi {
-        mac: "00:35:1a:90:56:03".to_string(),
-        ssid: "OurTest".to_string(),
-        channel: "112".to_string(),
-        signal_level: "-70".to_string(),
-        security: "WPA2(PSK/AES/AES)".to_string(),
-    });
-
-    expected.push(Wifi {
-        mac: "00:35:1a:90:56:00".to_string(),
-        ssid: "TEST-Wifi".to_string(),
-        channel: "1".to_string(),
-        signal_level: "-67".to_string(),
-        security: "WPA2(PSK/AES/AES)".to_string(),
-    });
-
-    // FIXME: should be a better way to create test fixtures
-    use std::path::PathBuf;
-    let mut path = PathBuf::new();
-    path.push("tests");
-    path.push("fixtures");
-    path.push("airport");
-    path.push("airport01.txt");
-
-    let file_path = path.as_os_str();
-
-    use std::fs::File;
-    use std::io::Read;
-
-    let mut file = File::open(&file_path).unwrap();
-
-    let mut filestr = String::new();
-    let result = file.read_to_string(&mut filestr).unwrap();
-    // println!("Read {} bytes", result);
-
-    let result = parse_airport(&filestr).unwrap();
-    let last = result.len() - 1;
-    assert_eq!(expected[0], result[0]);
-    assert_eq!(expected[1], result[last]);
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,0 +1,197 @@
+#[doc(no_inline)]
+use regex::Regex;
+use super::{Wifi, Error};
+
+/// Returns a list of WiFi hotspots in your area - (Linux) uses `iwlist`
+pub fn scan() -> Result<Vec<Wifi>, Error> {
+    use std::env;
+    use std::process::Command;
+
+    const PATH_ENV: &'static str = "PATH";
+    let path_system = "/usr/sbin:/sbin";
+    let path = env::var_os(PATH_ENV).map_or(path_system.to_string(), |v| {
+        format!("{}:{}", v.to_string_lossy().into_owned(), path_system)
+    });
+
+    let output = try!(Command::new("iwlist")
+                      .env(PATH_ENV, path)
+                      .arg("scan")
+                      .output()
+                      .map_err(|_| Error::CommandNotFound));
+
+    let data = String::from_utf8_lossy(&output.stdout);
+
+    parse_iwlist(&data)
+}
+
+#[allow(dead_code)]
+fn parse_iwlist(network_list: &str) -> Result<Vec<Wifi>, Error> {
+    let mut wifis: Vec<Wifi> = Vec::new();
+
+    let cell_regex = try!(Regex::new(r"Cell [0-9]{2,} - Address:")
+                              .map_err(|_| Error::SyntaxRegexError));
+
+    let mac_regex =
+        try!(Regex::new(r"([0-9a-zA-Z]{1}[0-9a-zA-Z]{1}[:]{1}){5}[0-9a-zA-Z]{1}[0-9a-zA-Z]{1}")
+                 .map_err(|_| Error::SyntaxRegexError));
+
+    for block in cell_regex.split(&network_list) {
+        let mut lines = block.lines();
+
+        let mut wifi_mac = String::new();
+        let mut wifi_ssid = String::new();
+        let mut wifi_channel = String::new();
+        let mut wifi_rssi = String::new();
+        let wifi_security = String::new(); // FIXME needs implementing
+
+        let mac_matches = mac_regex.captures(try!(lines.next().ok_or(Error::NoValue)));
+
+        if let Some(matches) = mac_matches {
+            if let Some(mac) = matches.at(0) {
+                wifi_mac = mac.to_string();
+            }
+        }
+
+        for line in lines {
+            if line.find("ESSID:").is_some() {
+                let ssid = line.split(":").nth(1).unwrap_or("").replace("\"", "");
+                wifi_ssid = ssid.to_string();
+            } else if line.find("Frequency:").is_some() {
+                wifi_channel = line.split("Channel")
+                                   .nth(1)
+                                   .unwrap_or("")
+                                   .replace(")", "")
+                                   .trim()
+                                   .to_string();
+                // println!("Channel: {}", wifi_channel);
+            } else if line.find("Signal level").is_some() {
+                if line.find("Quality").is_some() {
+                    // case1
+                    wifi_rssi = line.split("Signal level=")
+                                    .nth(1)
+                                    .unwrap_or("")
+                                    .replace("dBm", "")
+                                    .trim()
+                                    .to_string();
+                    // println!("Signal level (case1): {}", wifi_rssi);
+                } else {
+                    let re = try!(Regex::new(r"Signal level=(\d+)/100")
+                                      .map_err(|_| Error::SyntaxRegexError));
+                    let value_raw = try!(try!(re.captures(line).ok_or(Error::FailedToParse))
+                                             .at(1)
+                                             .ok_or(Error::NoValue));
+                    let value = try!(value_raw.parse::<i32>().map_err(|_| Error::FailedToParse));
+                    let strength_calc = ((100 * value) / 100) / 2 - 100;
+                    wifi_rssi = strength_calc.to_string();
+
+                    // println!("Signal level (case3): {}", wifi_rssi);
+                }
+            }
+
+
+            // FIXME make less vomit inducing
+            if !wifi_ssid.is_empty() && !wifi_mac.is_empty() && !wifi_rssi.is_empty() {
+                wifis.push(Wifi {
+                    ssid: wifi_ssid.to_string(),
+                    mac: wifi_mac.to_string(),
+                    channel: wifi_channel.to_string(),
+                    signal_level: wifi_rssi.to_string(),
+                    security: wifi_security.to_string(),
+                });
+
+                wifi_ssid = String::new();
+                wifi_mac = String::new();
+                wifi_rssi = String::new();
+                wifi_channel = String::new();
+            }
+        } // for
+    }
+    Ok(wifis)
+}
+
+#[test]
+fn should_parse_iwlist_type_1() {
+    let mut expected: Vec<Wifi> = Vec::new();
+    expected.push(Wifi {
+        mac: "00:35:1A:6F:0F:40".to_string(),
+        ssid: "TEST-Wifi".to_string(),
+        channel: "6".to_string(),
+        signal_level: "-72".to_string(),
+        security: "".to_string(),
+    });
+
+    expected.push(Wifi {
+        mac: "00:F2:8B:8F:58:77".to_string(),
+        ssid: "<hidden>".to_string(),
+        channel: "11".to_string(),
+        signal_level: "-71".to_string(),
+        security: "".to_string(),
+    });
+
+    // FIXME: should be a better way to create test fixtures
+    use std::path::PathBuf;
+    let mut path = PathBuf::new();
+    path.push("tests");
+    path.push("fixtures");
+    path.push("iwlist");
+    path.push("iwlist01_ubuntu1404.txt");
+
+    let file_path = path.as_os_str();
+
+    use std::fs::File;
+    use std::io::Read;
+
+    let mut file = File::open(&file_path).unwrap();
+
+    let mut filestr = String::new();
+    let result = file.read_to_string(&mut filestr).unwrap();
+    // println!("Read {} bytes", result);
+
+    let result = parse_iwlist(&filestr).unwrap();
+    assert_eq!(expected[0], result[0]);
+    assert_eq!(expected[1], result[28]);
+}
+
+#[test]
+fn should_parse_iwlist_type_2() {
+    let mut expected: Vec<Wifi> = Vec::new();
+
+    expected.push(Wifi {
+        mac: "D4:D1:84:50:76:45".to_string(),
+        ssid: "gsy-97796".to_string(),
+        channel: "6".to_string(),
+        signal_level: "-76".to_string(),
+        security: "".to_string(),
+    });
+
+    expected.push(Wifi {
+        mac: "7C:B7:33:AE:3B:05".to_string(),
+        ssid: "visitor-18170".to_string(),
+        channel: "9".to_string(),
+        signal_level: "-70".to_string(),
+        security: "".to_string(),
+    });
+
+    // FIXME: should be a better way to create test fixtures
+    use std::path::PathBuf;
+    let mut path = PathBuf::new();
+    path.push("tests");
+    path.push("fixtures");
+    path.push("iwlist");
+    path.push("iwlist02_raspi.txt");
+
+    let file_path = path.as_os_str();
+
+    use std::fs::File;
+    use std::io::Read;
+
+    let mut file = File::open(&file_path).unwrap();
+
+    let mut filestr = String::new();
+    let result = file.read_to_string(&mut filestr).unwrap();
+    // println!("Read {} bytes", result);
+
+    let result = parse_iwlist(&filestr).unwrap();
+    assert_eq!(expected[0], result[0]);
+    assert_eq!(expected[1], result[2]);
+}

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,0 +1,93 @@
+use regex::Regex;
+use super::{Wifi, Error};
+
+/// Returns a list of WiFi hotspots in your area - (OSX/MacOS) uses `airport`
+pub fn scan() -> Result<Vec<Wifi>, Error> {
+    use std::process::Command;
+    let output = try!(Command::new("/System/Library/PrivateFrameworks/Apple80211.\
+    framework/Versions/Current/Resources/airport")
+                          .arg("-s")
+                          .output()
+                          .map_err(|_| Error::CommandNotFound));
+
+    let data = String::from_utf8_lossy(&output.stdout);
+
+    parse_airport(&data)
+}
+
+#[allow(dead_code)]
+fn parse_airport(network_list: &str) -> Result<Vec<Wifi>, Error> {
+    let mut wifis: Vec<Wifi> = Vec::new();
+    let mut lines = network_list.lines();
+    let headers = lines.next().unwrap();
+
+    let headers_string = String::from(headers);
+    // FIXME: Turn these into non panicking Errors (ok_or breaks it)
+    let col_mac = headers_string.find("BSSID").expect("failed to find BSSID");
+    let col_rrsi = headers_string.find("RSSI").expect("failed to find RSSI");
+    let col_channel = headers_string.find("CHANNEL").expect("failed to find CHANNEL");
+    let col_ht = headers_string.find("HT").expect("failed to find HT");
+    let col_security = headers_string.find("SECURITY").expect("failed to find SECURITY");
+
+    for line in lines {
+        let ssid = &line[..col_mac].trim();
+        let mac = &line[col_mac..col_rrsi].trim();
+        let signal_level = &line[col_rrsi..col_channel].trim();
+        let channel = &line[col_channel..col_ht].trim();
+        let security = &line[col_security..].trim();
+
+        wifis.push(Wifi {
+            mac: mac.to_string(),
+            ssid: ssid.to_string(),
+            channel: channel.to_string(),
+            signal_level: signal_level.to_string(),
+            security: security.to_string(),
+        });
+    }
+
+    Ok(wifis)
+}
+
+#[test]
+fn should_parse_airport() {
+    let mut expected: Vec<Wifi> = Vec::new();
+    expected.push(Wifi {
+        mac: "00:35:1a:90:56:03".to_string(),
+        ssid: "OurTest".to_string(),
+        channel: "112".to_string(),
+        signal_level: "-70".to_string(),
+        security: "WPA2(PSK/AES/AES)".to_string(),
+    });
+
+    expected.push(Wifi {
+        mac: "00:35:1a:90:56:00".to_string(),
+        ssid: "TEST-Wifi".to_string(),
+        channel: "1".to_string(),
+        signal_level: "-67".to_string(),
+        security: "WPA2(PSK/AES/AES)".to_string(),
+    });
+
+    // FIXME: should be a better way to create test fixtures
+    use std::path::PathBuf;
+    let mut path = PathBuf::new();
+    path.push("tests");
+    path.push("fixtures");
+    path.push("airport");
+    path.push("airport01.txt");
+
+    let file_path = path.as_os_str();
+
+    use std::fs::File;
+    use std::io::Read;
+
+    let mut file = File::open(&file_path).unwrap();
+
+    let mut filestr = String::new();
+    let result = file.read_to_string(&mut filestr).unwrap();
+    // println!("Read {} bytes", result);
+
+    let result = parse_airport(&filestr).unwrap();
+    let last = result.len() - 1;
+    assert_eq!(expected[0], result[0]);
+    assert_eq!(expected[1], result[last]);
+}

--- a/src/openbsd.rs
+++ b/src/openbsd.rs
@@ -1,0 +1,285 @@
+use nix::libc::{freeifaddrs, getifaddrs, ifaddrs};
+use nix::sys::socket::{socket, AddressFamily, SockType, SockFlag, SockProtocol};
+use std::ffi::{CStr, CString};
+use std::os::unix::io::RawFd;
+use std::mem;
+use std::ptr;
+use super::{Wifi, Error};
+
+pub struct Socket {
+    pub ifname: String,
+    fd: RawFd,
+    cifname: CString,
+}
+
+fn find_interface() -> Result<Socket, Error> {
+    fn is_wireless(sock: RawFd, iname: &CStr) -> bool {
+        let mut mediareq = raw::ifmediareq::new(iname);
+
+        // if we don't support this ioctl, then we're definitely not wireless
+        if let Err(_) = unsafe { raw::get_ifmedia(sock, &mut mediareq) } {
+            return false;
+        };
+
+        (mediareq.current & raw::IFM_MASK) == raw::IFM_IEEE80211
+    }
+
+    let sock = socket(
+        AddressFamily::Inet,
+        SockType::Datagram,
+        SockFlag::empty(),
+        SockProtocol::Udp,
+    ).or_else(|e| Err(Error::NixError(e)))?;
+
+    let mut wireless: Vec<String> = Vec::new();
+
+    unsafe {
+        let mut interfaces: *mut ifaddrs = ptr::null_mut();
+        let head = interfaces;
+
+        // get list of interfaces
+        getifaddrs(&mut interfaces);
+
+        while (*interfaces).ifa_next != 0 as *mut ifaddrs {
+            // extract the name
+            let iname = CStr::from_ptr((*interfaces).ifa_name);
+
+            // determine if we have a wireless interface
+            if is_wireless(sock, &iname) {
+                let name = String::from(iname.to_str().unwrap());
+                if !wireless.contains(&name) {
+                    wireless.push(name);
+                }
+            }
+
+            interfaces = (*interfaces).ifa_next;
+        }
+
+        freeifaddrs(head);
+    }
+
+    if wireless.len() == 1 {
+        let ifname = wireless.pop().unwrap();
+        let cifname = CString::new(ifname.as_str()).unwrap();
+
+        Ok(Socket {
+            ifname,
+            fd: sock,
+            cifname,
+        })
+    } else if wireless.len() == 0 {
+        Err(Error::DiscoveryError("no wireless devices found"))
+    } else {
+        Err(Error::DiscoveryError("too many wireless devices found"))
+    }
+}
+
+pub fn scan() -> Result<Vec<Wifi>, Error> {
+    let sock = find_interface()?;
+
+    let req = raw::ifreq::new(sock.cifname.as_c_str());
+    // put the interface into scan mode
+    unsafe { raw::set_80211scan(sock.fd, &req)? };
+
+    let raw_results: [raw::ieee80211_nodereq; 512] = [raw::ieee80211_nodereq::default(); 512];
+    let mut raw_container = raw::ieee80211_nodereq_all::new(
+        sock.cifname.as_c_str(),
+        &raw_results as *const raw::ieee80211_nodereq,
+        mem::size_of_val(&raw_results),
+    );
+
+    // collect the results
+    unsafe { raw::get_allnodes(sock.fd, &mut raw_container)? };
+
+    let mut results: Vec<Wifi> = Vec::new();
+
+    for i in 0..raw_container.nodes as usize {
+        let bssid = raw_results[i].bssid;
+        results.push(Wifi {
+            mac: format!("{:x}:{:x}:{:x}:{:x}:{:x}:{:x}", bssid[0], bssid[1], bssid[2], bssid[3], bssid[4], bssid[5]),
+            ssid: raw::nwid_to_str(&raw_results[i].nwid)?,
+            channel: format!("{}", raw_results[i].channel),
+            signal_level: format!("{}", raw_results[i].rssi),
+            security: format!("{}", raw_results[i].capinfo),
+        });
+    }
+
+    Ok(results)
+}
+
+#[allow(non_camel_case_types)]
+mod raw {
+    use nix::libc::{c_int, c_short, c_uint, c_void, size_t, sockaddr, uint64_t};
+    use std::ffi;
+    use std::mem;
+    use std::ptr;
+    use std::result;
+    use std::string::FromUtf8Error;
+
+    const IFNAMSIZ: usize = 16;
+    const IEEE80211_ADDR_LEN: usize = 6; // net80211/ieee80211.h
+    const IEEE80211_NWID_LEN: usize = 32; // net80211/ieee80211.h
+    const IEEE80211_RATE_MAXSIZE: usize = 15; // net80211/ieee80211.h
+
+    pub const IFM_IEEE80211: u64 = 0x400;
+    pub const IFM_MASK: u64 = 0xff00;
+
+    fn cstr_to_ifname(name: &ffi::CStr) -> [i8; 16] {
+        let mut name16: [i8; 16] = [0; 16];
+        let name_arr = name.to_bytes_with_nul();
+
+        for i in 0..14 {
+            if i < name_arr.len() {
+                name16[i] = name_arr[i] as i8;
+            }
+        }
+
+        name16
+    }
+
+    pub fn nwid_to_str(nwid: &[u8]) -> result::Result<String, FromUtf8Error> {
+        let mut v = nwid.to_vec();
+
+        if nwid[0] == 0 {
+            return Ok(String::new());
+        }
+
+        v.retain(|&x| x != 0);
+
+        String::from_utf8(v)
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct ifmediareq {
+        pub name: [i8; IFNAMSIZ],
+        pub current: u64,
+        pub mask: u64,
+        pub status: u64,
+        pub active: u64,
+        pub count: c_int,
+        pub ulist: *mut u64,
+    }
+
+    impl ifmediareq {
+        pub fn new(name: &ffi::CStr) -> Self {
+            ifmediareq {
+                name: cstr_to_ifname(name),
+                current: 0,
+                mask: 0,
+                status: 0,
+                active: 0,
+                count: 0,
+                ulist: ptr::null_mut(),
+            }
+        }
+    }
+
+    #[repr(C)]
+    union ifr_ifru {
+        pub addr: sockaddr,
+        pub dstaddr: sockaddr,
+        pub broadaddr: sockaddr,
+        pub flags: c_short,
+        pub metric: c_int,
+        pub media: uint64_t,
+        pub data: *mut c_void
+    }
+
+    #[repr(C)]
+    pub struct ifreq {
+        name: [i8; IFNAMSIZ],
+        ifru: ifr_ifru,
+    }
+
+    impl ifreq {
+        pub fn new(name: &ffi::CStr) -> Self {
+            ifreq {
+                name: cstr_to_ifname(name),
+                ifru: unsafe { mem::zeroed() },
+            }
+        }
+    }
+
+    // /usr/include/net80211/ieee80211_ioctl.h
+    #[repr(C)]
+    #[derive(Clone, Copy, Debug, Default)]
+    pub struct ieee80211_nodereq {
+        pub name: [i8; IFNAMSIZ],
+
+        pub macaddr: [u8; IEEE80211_ADDR_LEN],
+        pub bssid: [u8; IEEE80211_ADDR_LEN],
+        pub nwid_len: u8,
+        pub nwid: [u8; IEEE80211_NWID_LEN],
+
+        pub channel: u16,
+        pub chan_flags: u16,
+        pub nrates: u8,
+        pub rates: [u8; IEEE80211_RATE_MAXSIZE],
+
+        pub rssi: i8,
+        pub max_rssi: i8,
+        pub tstamp: [u8; 8],
+        pub intval: u16,
+        pub capinfo: u16,
+        pub erp: u8,
+        pub pwrsave: u8,
+        pub associd: u16,
+        pub txseq: u16,
+        pub rxseq: u16,
+        pub fails: u32,
+        pub inact: u32,
+        pub txrate: u8,
+        pub state: u16,
+
+        pub rsnproto: c_uint,
+        pub rsnciphers: c_uint,
+        pub rsnakms: c_uint,
+
+        pub flags: u8,
+
+        pub htcaps: u16,
+        pub rxmcs: [u8; 10], // howmany(80, NBBY) where NBBY = 8
+        pub max_rxrate: u16,
+        pub tx_mcs_set: u8,
+        pub txmcs: u8,
+    }
+
+    // /usr/include/net80211/ieee80211_ioctl.h
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct ieee80211_nodereq_all {
+        pub name: [i8; IFNAMSIZ],
+        pub nodes: c_int,
+        pub size: size_t,
+        pub node: *const ieee80211_nodereq,
+        pub flags: u8,
+    }
+
+    impl Default for ieee80211_nodereq_all {
+        fn default() -> Self {
+            unsafe { mem::zeroed() }
+        }
+    }
+
+    impl ieee80211_nodereq_all {
+        pub fn new(name: &ffi::CStr, node: *const ieee80211_nodereq, size: size_t) -> Self {
+            let mut ret = Self::default();
+
+            ret.name = cstr_to_ifname(name);
+            ret.node = node;
+            ret.size = size;
+            ret
+        }
+    }
+
+
+    const SIOCIF_MAGIC: u8 = b'i';
+    const SIOCGIFMEDIA: u8 = 56;
+    const SIOCS80211SCAN: u8 = 210;
+    const SIOCG80211ALLNODES: u8 = 214;
+
+    ioctl!(readwrite get_ifmedia with SIOCIF_MAGIC, SIOCGIFMEDIA; ifmediareq);
+    ioctl!(write_ptr set_80211scan with SIOCIF_MAGIC, SIOCS80211SCAN; ifreq);
+    ioctl!(readwrite get_allnodes with SIOCIF_MAGIC, SIOCG80211ALLNODES; ieee80211_nodereq_all);
+}


### PR DESCRIPTION
Instead of calling out `ifconfig(8)` and then parsing the results,
we use the `ioctl(2)` calls that OpenBSD provides to get the info
directly from the kernel.

- Reorganize for better cross-platform support