### PR TITLE
Handle iw scan failures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,11 +45,14 @@ extern crate regex;
 
 mod sys;
 
+use std::process::ExitStatus;
+
 #[allow(missing_docs)]
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     SyntaxRegexError,
     CommandNotFound,
+    CommandFailed(ExitStatus, String),
     NoMatch,
     FailedToParse,
     NoValue,

--- a/src/sys/linux.rs
+++ b/src/sys/linux.rs
@@ -25,6 +25,12 @@ pub(crate) fn scan() -> Result<Vec<Wifi>, Error> {
         .arg("scan")
         .output()
         .map_err(|_| Error::CommandNotFound)?;
+    if !output.status.success() {
+        return Err(Error::CommandFailed(
+            output.status,
+            String::from_utf8_lossy(&output.stderr).to_string(),
+        ));
+    }
     let data = String::from_utf8_lossy(&output.stdout);
     parse_iw_dev_scan(&data)
 }


### PR DESCRIPTION
On my machine scanning often fails when I'm not connected to any access point:

```
$ sudo iw dev wlp2s0 scan ; echo $?
command failed: Device or resource busy (-16)
240
```