### PR TITLE
Add support for commandline output (closes #33)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 keywords = ["wifi","hotspots","network"]
 license = "Apache-2.0"
 
+[[bin]]
+name = "wifiscanner"
+
 [dependencies]
 regex = "1"
 itertools = "0.8.0"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let networks = wifiscanner::scan().expect("Cannot scan network");
+    for network in networks {
+        println!(
+            "{} {:15} {:10} {:4} {}",
+            network.mac, network.ssid, network.channel, network.signal_level, network.security
+        );
+    }
+}


### PR DESCRIPTION
This adds very rudimentary support to print the output of
`wifiscanner` to the commandline. As of now, this is simply a `bin/main.rs`
file that iterates over all networks and prints them in order.

The binary can then be installed with `cargo install` via crates.io
to streamline the user-experience.