### PR TITLE
feat: [ci] automatic deploy to crates.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,33 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+
+  deploy:
+    name: Deploy & Release
+    needs: test
+    if: startsWith(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Build & Deploy to crates.io
+        run: |
+          cargo build --release
+          cargo publish --token ${{ secrets.CRATES_TOKEN }}
+
+      - name: Create Github Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # already provided by GH Actions
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
When a new tag is created, a specific deploy job is triggered. It deploys the lib to crates.io (you need to add the CRATES_TOKEN) and creates a new release based on that tag.

Closes #39