### PR TITLE
Fix panic on no networks being detected on MacOS

### DIFF
--- a/src/sys/macos.rs
+++ b/src/sys/macos.rs
@@ -20,6 +20,9 @@ fn parse_airport(network_list: &str) -> Result<Vec<Wifi>> {
     let mut wifis: Vec<Wifi> = Vec::new();
     let mut lines = network_list.lines();
     let headers = match lines.next() {
+        // Sometimes, if no networks are found it prints "no networks found"
+        // instead of producing empty output. Not sure what determines which action is taken.
+        Some("No networks found") => return Ok(vec![]),
         Some(v) => v,
         // return an empty list of WiFi if the network_list is empty
         None => return Ok(vec![]),


### PR DESCRIPTION
Sometimes, `airport` prints an error message to the terminal instead of returning nothing when no networks are found, causing a panic when trying to parse the output later. Take this into account. Tested on MacOS Ventura.

I had a brief look at the `airport` binary, it seems like the error messages are not translated and this fix should therefore also work on non-english systems.